### PR TITLE
Allow the console to be opened at a directory

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -87,7 +87,7 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
   debug('APP setting session variables: %O %O', req.params, req.query);
   // capture, assign, and validated variables
   req.session.ssh = {
-    dir: req.query.dir,
+    dir: ((req.query.dir + '').match(/^[0-9a-zA-Z_ ./-]*$/) && req.query.dir) || null,
     host: (validator.isIP(req.params.host + '') && req.params.host) ||
       (validator.isFQDN(req.params.host) && req.params.host) ||
       (/^(([a-z]|[A-Z]|[0-9]|[!^(){}\-_~])+)?\w$/.test(req.params.host) &&

--- a/src/app.js
+++ b/src/app.js
@@ -87,6 +87,7 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
   debug('APP setting session variables: %O %O', req.params, req.query);
   // capture, assign, and validated variables
   req.session.ssh = {
+    dir: req.query.dir,
     host: (validator.isIP(req.params.host + '') && req.params.host) ||
       (validator.isFQDN(req.params.host) && req.params.host) ||
       (/^(([a-z]|[A-Z]|[0-9]|[!^(){}\-_~])+)?\w$/.test(req.params.host) &&

--- a/src/sshConnection.js
+++ b/src/sshConnection.js
@@ -95,7 +95,7 @@ module.exports = function socket (socket) {
           }
 
           // Move to the given directory
-          stream.write("cd /tmp #--flight-console-hidden--\n");
+          stream.write("cd /tmp\n");
 
           socket.on('data', function socketOnData (data) {
             stream.write(data)
@@ -123,9 +123,7 @@ module.exports = function socket (socket) {
           })
 
           stream.on('data', function streamOnData (data) {
-            // Remove lines which trail with the hidden comment
-            // This allows commands to be ran in the "background" without notifying the user
-            socket.emit('data', data.toString('utf-8').replace(/^.*#--flight-console-hidden--\r?\n/g, ''))
+            socket.emit('data', data.toString('utf-8'));
           })
 
           stream.on('close', function streamOnClose (code, signal) {

--- a/src/sshConnection.js
+++ b/src/sshConnection.js
@@ -87,7 +87,7 @@ module.exports = function socket (socket) {
         if (sshConfig.dir) {
           conn.sftp(function(err, sftp) {
             if (err) {
-              SSHError('EXEC ERROR' + err);
+              SSHerror('EXEC ERROR' + err);
               waterfall(true, null);
             } else {
               sftp.opendir(sshConfig.dir, function(err, _buffer) {

--- a/src/sshConnection.js
+++ b/src/sshConnection.js
@@ -121,7 +121,6 @@ module.exports = function socket (socket) {
         }, function connShell (err, stream) {
           if (err) {
             SSHerror('EXEC ERROR' + err)
-            conn.end();
             waterfall(true, null);
           }
 
@@ -146,13 +145,13 @@ module.exports = function socket (socket) {
             debug('SOCKET DISCONNECT: ' + reason)
             err = { message: reason }
             SSHerror('CLIENT SOCKET DISCONNECT', err)
-            conn.end()
+            waterfall(true, null);
             // socket.request.session.destroy()
           })
 
           socket.on('error', function socketOnError (err) {
             SSHerror('SOCKET ERROR', err)
-            conn.end()
+            waterfall(true, null);
           })
 
           stream.on('data', function streamOnData (data) {
@@ -165,6 +164,10 @@ module.exports = function socket (socket) {
             if (signal) { messages.push(`SIGNAL: ${signal}`); }
             SSHerror('STREAM CLOSE', { message: messages.join(' ') })
             waterfall(true, null);
+          })
+
+          stream.stderr.on('data', function streamStderrOnData (data) {
+            console.log('STDERR: ' + data)
           })
         })
       }

--- a/src/sshConnection.js
+++ b/src/sshConnection.js
@@ -83,6 +83,9 @@ module.exports = function socket (socket) {
         return
       }
 
+      // Move to the given directory
+      stream.write("cd /tmp #--flight-console-hidden--\n");
+
       socket.on('data', function socketOnData (data) {
         stream.write(data)
       })
@@ -109,7 +112,9 @@ module.exports = function socket (socket) {
       })
 
       stream.on('data', function streamOnData (data) {
-        socket.emit('data', data.toString('utf-8'))
+        // Remove lines which trail with the hidden comment
+        // This allows commands to be ran in the "background" without notifying the user
+        socket.emit('data', data.toString('utf-8').replace(/^.*#--flight-console-hidden--\r?\n/g, ''))
       })
 
       stream.on('close', function streamOnClose (code, signal) {

--- a/src/sshConnection.js
+++ b/src/sshConnection.js
@@ -2,6 +2,7 @@
 'use strict'
 /* jshint esversion: 6, asi: true, node: true */
 
+const async = require('async');
 const debug = require('debug')('flight:console')
 const SSH = require('ssh2').Client
 const CIDRMatcher = require('cidr-matcher')
@@ -60,76 +61,87 @@ module.exports = function socket (socket) {
     socket.emit('data', data.toString('utf-8'));
   })
 
-  conn.on('ready', function connOnReady () {
-    console.log(
-      'Flight console Login:' +
-      ' user=' + session.username +
-      ' from=' + socket.handshake.address +
-      ' host=' + sshConfig.host +
-      ' port=' + sshConfig.port +
-      ' sessionID=' + socket.request.sessionID + '/' + socket.id +
-      ' mrhsession=' + sshConfig.mrhsession +
-      ' term=' + sshConfig.term
-    );
-    socket.emit('status', 'SSH CONNECTION ESTABLISHED');
-    conn.shell({
-      term: sshConfig.term,
-      cols: termCols,
-      rows: termRows
-    }, function connShell (err, stream) {
-      if (err) {
-        SSHerror('EXEC ERROR' + err)
-        conn.end()
-        return
+  async.waterfall([
+      // Wait until the connection is ready
+      function(waterfall) {
+        conn.on('ready', function connOnReady() {
+          console.log(
+            'Flight console Login:' +
+            ' user=' + session.username +
+            ' from=' + socket.handshake.address +
+            ' host=' + sshConfig.host +
+            ' port=' + sshConfig.port +
+            ' sessionID=' + socket.request.sessionID + '/' + socket.id +
+            ' mrhsession=' + sshConfig.mrhsession +
+            ' term=' + sshConfig.term
+          );
+          socket.emit('status', 'SSH CONNECTION ESTABLISHED');
+
+          waterfall(null, null);
+        })
+      },
+
+      // Establish the SSH connection in a PTY
+      function(_, waterfall) {
+        conn.shell({
+          term: sshConfig.term,
+          cols: termCols,
+          rows: termRows
+        }, function connShell (err, stream) {
+          if (err) {
+            SSHerror('EXEC ERROR' + err)
+            conn.end();
+            waterfall(true, null);
+          }
+
+          // Move to the given directory
+          stream.write("cd /tmp #--flight-console-hidden--\n");
+
+          socket.on('data', function socketOnData (data) {
+            stream.write(data)
+          })
+
+          socket.on('resize', function socketOnResize (data) {
+            stream.setWindow(data.rows, data.cols)
+          })
+
+          socket.on('disconnecting', function socketOnDisconnecting (reason) {
+            debug('SOCKET DISCONNECTING: ' + reason)
+          })
+
+          socket.on('disconnect', function socketOnDisconnect (reason) {
+            debug('SOCKET DISCONNECT: ' + reason)
+            err = { message: reason }
+            SSHerror('CLIENT SOCKET DISCONNECT', err)
+            conn.end()
+            // socket.request.session.destroy()
+          })
+
+          socket.on('error', function socketOnError (err) {
+            SSHerror('SOCKET ERROR', err)
+            conn.end()
+          })
+
+          stream.on('data', function streamOnData (data) {
+            // Remove lines which trail with the hidden comment
+            // This allows commands to be ran in the "background" without notifying the user
+            socket.emit('data', data.toString('utf-8').replace(/^.*#--flight-console-hidden--\r?\n/g, ''))
+          })
+
+          stream.on('close', function streamOnClose (code, signal) {
+            let messages = [];
+            if (code)   { messages.push(`CODE: ${code}`); }
+            if (signal) { messages.push(`SIGNAL: ${signal}`); }
+            SSHerror('STREAM CLOSE', { message: messages.join(' ') })
+            waterfall(true, null);
+          })
+        })
       }
+    ],
 
-      // Move to the given directory
-      stream.write("cd /tmp #--flight-console-hidden--\n");
-
-      socket.on('data', function socketOnData (data) {
-        stream.write(data)
-      })
-
-      socket.on('resize', function socketOnResize (data) {
-        stream.setWindow(data.rows, data.cols)
-      })
-
-      socket.on('disconnecting', function socketOnDisconnecting (reason) {
-        debug('SOCKET DISCONNECTING: ' + reason)
-      })
-
-      socket.on('disconnect', function socketOnDisconnect (reason) {
-        debug('SOCKET DISCONNECT: ' + reason)
-        err = { message: reason }
-        SSHerror('CLIENT SOCKET DISCONNECT', err)
-        conn.end()
-        // socket.request.session.destroy()
-      })
-
-      socket.on('error', function socketOnError (err) {
-        SSHerror('SOCKET ERROR', err)
-        conn.end()
-      })
-
-      stream.on('data', function streamOnData (data) {
-        // Remove lines which trail with the hidden comment
-        // This allows commands to be ran in the "background" without notifying the user
-        socket.emit('data', data.toString('utf-8').replace(/^.*#--flight-console-hidden--\r?\n/g, ''))
-      })
-
-      stream.on('close', function streamOnClose (code, signal) {
-        let messages = [];
-        if (code)   { messages.push(`CODE: ${code}`); }
-        if (signal) { messages.push(`SIGNAL: ${signal}`); }
-        SSHerror('STREAM CLOSE', { message: messages.join(' ') })
-        conn.end()
-      })
-
-      stream.stderr.on('data', function streamStderrOnData (data) {
-        console.log('STDERR: ' + data)
-      })
-    })
-  })
+    // Close the connection
+    function(_, _a) { conn.end(); }
+  )
 
   conn.on('end', function connOnEnd (err) {
     SSHerror('CONN END BY HOST', err);

--- a/src/sshConnection.js
+++ b/src/sshConnection.js
@@ -73,6 +73,7 @@ module.exports = function socket (socket) {
             ' port=' + sshConfig.port +
             ' sessionID=' + socket.request.sessionID + '/' + socket.id +
             ' mrhsession=' + sshConfig.mrhsession +
+            ' dir=' + sshConfig.dir +
             ' term=' + sshConfig.term
           );
           socket.emit('status', 'SSH CONNECTION ESTABLISHED');

--- a/src/sshConnection.js
+++ b/src/sshConnection.js
@@ -83,27 +83,32 @@ module.exports = function socket (socket) {
 
       // Determine if the requested directory exists using SFTP
       function(_, waterfall) {
-        var dir = '/tmp';
-        conn.sftp(function(err, sftp) {
-          if (err) {
-            SSHError('EXEC ERROR' + err);
-            waterfall(true, null);
-          } else {
-            sftp.opendir(dir, function(err, _buffer) {
-              // Assumable the directory does not exist
-              // TODO: Check permissions issues?
-              if (err) {
-                debug("Requested directory: " + dir);
-                debug(err);
-                waterfall(null, null);
+        if (sshConfig.dir) {
+          conn.sftp(function(err, sftp) {
+            if (err) {
+              SSHError('EXEC ERROR' + err);
+              waterfall(true, null);
+            } else {
+              sftp.opendir(sshConfig.dir, function(err, _buffer) {
+                // Assumable the directory does not exist
+                // TODO: Check permissions issues?
+                if (err) {
+                  debug("Requested directory: " + sshConfig.dir);
+                  debug(err);
+                  waterfall(null, null);
 
-              // The directory does exist
-              } else {
-                waterfall(null, dir);
-              }
-            })
-          }
-        });
+                // The directory does exist
+                } else {
+                  waterfall(null, sshConfig.dir);
+                }
+              })
+            }
+          });
+
+        // Skip SFTP if the directory isn't given
+        } else {
+          waterfall(null, null);
+        }
       },
 
       // Establish the SSH connection in a PTY

--- a/src/sshConnection.js
+++ b/src/sshConnection.js
@@ -127,7 +127,7 @@ module.exports = function socket (socket) {
 
           // Move to the given directory (if given)
           if (working_dir) {
-            stream.write(`cd ${working_dir}\n`);
+            stream.write(`cd "${working_dir}"\n`);
           }
 
           socket.on('data', function socketOnData (data) {


### PR DESCRIPTION
A `dir` query parameter has been added to the `/ssh/host/:ip` to specify where the `console` should open:

* `GET /ssh/host/:ip?dir=/path/to/location`

---

As the `SSH2` library does not natively support "change directory", it has to be done manually by running `cd`:

https://github.com/openflighthpc/flight-console-api/blob/30bd2b04fe851c6662b4d1119eba61ab0fc68de2/src/sshConnection.js#L128

NOTE: This is essentially equivalent to running the following whilst still respecting the user's shell:
`ssh <ip>  "cd <dir> ; bash --login"`

This means the output of the `cd` command is visible to the user. I tried a few different ways to prevent this but concluded its best just to leave it. The rejected strategies include:

* Turning off terminal `ECHO` (`stty -echo`) => Ignored by `tcsh`, ugly in bash
* Magic trailing comments (`cd <dir> #--remove-me--`) => Breaks `tcsh`
* Re-creating the shell after the `cd` => Double prints the welcome banner OR became overly complicated.

---

As the output of `cd` is visible, ideally it should not result in an error. To prevent missing directories emitting an ugly output, their existence is first checked using the `SFTP`.

This proved to be easier than trying to determine the directories existence using `ls`.

NOTE: `tcsh` does not allow stderr to be redirected, so the following does not work:

```
tcsh
cd /missing 2>/dev/null
cd: Too many arguments.
```

---

Future enhancement:

Preform the directory existence check when the session is cached and return a `40x` error if it is missing. Currently it is done after the `SSH` connection is established, which makes providing an informative error tricky.