### PR TITLE
Handle various errors during the SFTP check

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "nodaemon": "0.0.5",
     "nodemon": "^2.0.3",
+    "pryjs": "^1.0.3",
     "snazzy": "^8.0.0",
     "standard": "^14.3.1",
     "standard-version": "^8.0.1"

--- a/src/app.js
+++ b/src/app.js
@@ -86,8 +86,7 @@ apiRouter.get('/ping', function(req, res, next) {
 apiRouter.get('/ssh/host/:host?', function (req, res, next) {
   debug('APP setting session variables: %O %O', req.params, req.query);
 
-  // capture, assign, and validated variables
-  req.session.unverified_dir = req.query.dir;
+  req.session.requestedDir = req.query.dir;
 
   req.session.ssh = {
     host: (validator.isIP(req.params.host + '') && req.params.host) ||

--- a/src/app.js
+++ b/src/app.js
@@ -122,13 +122,13 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
           .status(422)
           .header('Content-Type', 'application/json')
           .send(JSON.stringify( { errors: [ {
-            code: 'Unexpected SFTP STDOUT', type: 'SFTP', basic: true
+            code: 'Unexpected SFTP STDOUT', recoverable: true
           }]}))
       } else if (err.message.match(dir_regex)) {
         res.status(422)
            .header('Content-Type', 'application/json')
            .send(JSON.stringify({ errors: [{
-             code: err.message.substring(5), type: 'dir', basic: true
+             code: err.message.substring(5), recoverable: true
            }]}));
       } else if (err.level === 'client-authentication') {
         res

--- a/src/app.js
+++ b/src/app.js
@@ -109,7 +109,7 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
   }
 
   checkAuthentication(req.session)
-    .then(() => { res.status(200).send('OK') })
+    .then(() => { res.status(200).send({ pwd: req.session.ssh.pwd }) })
     .catch((err) => {
       debug('checkAuthentication failed: %o', err);
       if (err.level === 'client-authentication') {

--- a/src/app.js
+++ b/src/app.js
@@ -113,7 +113,10 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
   }
 
   checkAuthentication(req.session)
-    .then(() => { res.status(200).send({ pwd: req.session.ssh.pwd }) })
+    .then(() => { res.status(200).send({
+      pwd: req.session.ssh.pwd,
+      cwd: req.session.ssh.cwd || req.session.ssh.pwd
+    }) })
     .catch((err) => {
       debug('checkAuthentication failed: %o', err);
       const dir_regex = /^\?dir:/;

--- a/src/app.js
+++ b/src/app.js
@@ -112,7 +112,14 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
     .then(() => { res.status(200).send({ pwd: req.session.ssh.pwd }) })
     .catch((err) => {
       debug('checkAuthentication failed: %o', err);
-      if (err.level === 'client-authentication') {
+      if (err.message === 'Unexpected packet before version') {
+        res
+          .status(422)
+          .header('Content-Type', 'application/json')
+          .send(JSON.stringify( { errors: [ {
+            code: 'Unexpected SFTP STDOUT', recoverable: true
+          }]}))
+      } else if (err.level === 'client-authentication') {
         res
           .status(422)
           .header('Content-Type', 'application/json')

--- a/src/app.js
+++ b/src/app.js
@@ -122,13 +122,13 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
           .status(422)
           .header('Content-Type', 'application/json')
           .send(JSON.stringify( { errors: [ {
-            code: 'Unexpected SFTP STDOUT', recoverable: true
+            code: 'Unexpected SFTP STDOUT', type: 'SFTP'
           }]}))
       } else if (err.message.match(dir_regex)) {
         res.status(422)
            .header('Content-Type', 'application/json')
            .send(JSON.stringify({ errors: [{
-             code: err.message.substring(5), recoverable: true
+             code: err.message.substring(5), type: 'dir'
            }]}));
       } else if (err.level === 'client-authentication') {
         res

--- a/src/app.js
+++ b/src/app.js
@@ -122,13 +122,13 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
           .status(422)
           .header('Content-Type', 'application/json')
           .send(JSON.stringify( { errors: [ {
-            code: 'Unexpected SFTP STDOUT', type: 'SFTP'
+            code: 'Unexpected SFTP STDOUT', type: 'SFTP', basic: true
           }]}))
       } else if (err.message.match(dir_regex)) {
         res.status(422)
            .header('Content-Type', 'application/json')
            .send(JSON.stringify({ errors: [{
-             code: err.message.substring(5), type: 'dir'
+             code: err.message.substring(5), type: 'dir', basic: true
            }]}));
       } else if (err.level === 'client-authentication') {
         res

--- a/src/app.js
+++ b/src/app.js
@@ -87,9 +87,7 @@ apiRouter.get('/ssh/host/:host?', function (req, res, next) {
   debug('APP setting session variables: %O %O', req.params, req.query);
 
   // capture, assign, and validated variables
-  req.session.unverified_dir = (
-    (req.query.dir + '').match(/^[0-9a-zA-Z_ ./-]*$/) && req.query.dir
-  ) || null
+  req.session.unverified_dir = req.query.dir;
 
   req.session.ssh = {
     host: (validator.isIP(req.params.host + '') && req.params.host) ||

--- a/src/directoryChecker.js
+++ b/src/directoryChecker.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const async = require('async');
+const debug = require('debug')('flight:console:directoryChecker');
+
+class DirectoryChecker {
+  constructor(conn, requestedDir) {
+    this.conn = conn;
+    this.requestedDir = requestedDir;
+
+    // The path that relative directories are expanded against.  This would
+    // ideally be the user's home directory, but it is easier to use the
+    // directory that the user's non-interactive shell ends up in.  These are
+    // expected to be the same directory for almost all users.
+    this.pwd = null;
+
+    // The absolute path to the directory that has been requested.
+    this.cwd = null;
+  }
+
+  checkDirectory(callback) {
+    async.waterfall([
+      this.establishSFTPConnection.bind(this),
+      this.determinePWD.bind(this),
+      this.resolveGivenDirectory.bind(this),
+      this.checkDirExists.bind(this),
+      this.checkPermissions.bind(this),
+      this.returnDirectories.bind(this),
+    ],
+      callback
+    );
+  }
+
+  establishSFTPConnection(cb) {
+    debug("Starting directory check via SFTP");
+    this.conn.sftp((err, sftp) => {
+      if (err) {
+        cb(err, null);
+      } else {
+        debug('Established SFTP client')
+        cb(null, sftp);
+      }
+    })
+  }
+
+
+  // This will be used as the base directory from which relative paths are
+  // expanded.
+  //
+  // It would perhaps be better to expand from the user's home directory, but
+  // that would require determining the difference between a absolute and
+  // relative path before running the call to CD.
+  determinePWD(sftp, cb) {
+    debug("Determining PWD");
+    sftp.realpath('.', (err, path) => {
+      if (err) {
+        cb(err);
+      } else {
+        this.pwd = path;
+        debug('Determined PWD: ' + path)
+        cb(null, sftp);
+      }
+    });
+  }
+
+  resolveGivenDirectory(sftp, cb) {
+    if (this.requestedDir && this.requestedDir.match(/^[0-9a-zA-Z_ u./-]*$/)) {
+      debug("Resolving: " + this.requestedDir);
+      sftp.realpath(this.requestedDir, (err, dir) => {
+        if (err && err.message == "No such file") {
+          cb(new Error("?dir:Missing Directory"));
+        } else if (err) {
+          cb(err);
+        } else {
+          debug("Resolved: " + dir);
+          cb(null, sftp, dir);
+        }
+      });
+    } else if (this.requestedDir) {
+      debug("Invalid dir: " + this.requestedDir)
+      cb(new Error("?dir:Invalid Characters"));
+    } else {
+      // Trigger the next callback without a dir
+      cb(null, sftp, null)
+    }
+  }
+
+  checkDirExists(sftp, dir, cb) {
+    if (dir) {
+      debug("Checking directory exists: " + dir);
+      sftp.stat(dir, (err, stat) => {
+        if (err && err.message == "No such file") {
+          cb(new Error("?dir:Missing Directory"));
+        } else if (err) {
+          cb(err)
+        } else if (stat.permissions >= 0o40000 && stat.permissions < 0o50000) {
+          debug("Directory exists: " + dir)
+          cb(null, sftp, dir)
+        } else {
+          debug("Path is not a directory! " + stat.permissions.toString(8))
+          cb(new Error("?dir:Not A Directory"))
+        }
+      });
+    } else {
+      cb(null, sftp, null);
+    }
+  }
+
+  checkPermissions(sftp, dir, cb) {
+    if (dir) {
+      debug("Checking directory permissions: " + dir);
+      sftp.opendir(dir, (err, _) => {
+        if (err) {
+          cb(new Error("?dir:Permission Denied"))
+        } else {
+          this.cwd = dir;
+          debug("Checked directory permissions")
+          cb(null)
+        }
+      });
+    } else {
+      cb(null)
+    }
+  }
+
+  returnDirectories(cb) {
+    cb(null, this.pwd, this.cwd);
+  }
+}
+
+module.exports = DirectoryChecker;

--- a/src/sshUtils.js
+++ b/src/sshUtils.js
@@ -68,21 +68,29 @@ function checkAuthentication(session) {
         // Check if the directory exists
         function(sftp, dir, cb) {
           if (dir) {
-            debugSFTP("Verifying Directory: " + dir);
+            debugSFTP("Checking Directory Exists: " + dir);
             sftp.stat(dir, (err, stat) => {
               if (err && err.message == "No such file") {
                 cb(new Error("?dir:Missing Directory"));
               } else if (err) {
                 cb(err)
+              } else if (stat.permissions >= 0o40000 && stat.permissions < 0o50000) {
+                // Checks the permissions to ensure it is a directory
+                debugSFTP("Directory Exists: " + dir)
+                cb(null, sftp, dir)
               } else {
-                session.ssh.dir = dir
-                debugSFTP("Verified Directory: " + dir)
-                cb(null)
+                debugSFTP("Path is not a directory!")
+                cb(new Error("?dir:Not A Directory"))
               }
             });
           } else {
-            cb(null);
+            cb(null, sftp);
           }
+        },
+
+        // Check the user can open the directory
+        function(sftp, dir, cb) {
+          cb(null)
         }
       ],
 

--- a/src/sshUtils.js
+++ b/src/sshUtils.js
@@ -49,7 +49,8 @@ function checkAuthentication(session) {
 
         // Resolve the unverified_dir to an absolute path
         function(sftp, cb) {
-          if (session.unverified_dir) {
+          const d = session.unverified_dir
+          if (d && d.match(/^[0-9a-zA-Z_ u./-]*$/)) {
             debugSFTP("Resolving: " + session.unverified_dir);
             sftp.realpath(session.unverified_dir, (err, dir) => {
               if (err) {
@@ -59,6 +60,9 @@ function checkAuthentication(session) {
                 cb(null, sftp, dir);
               }
             });
+          } else if (d) {
+            debugSFTP("Invalid dir: " + d)
+            cb(new Error("?dir:Invalid Characters"));
           } else {
             // Trigger the next callback without a dir
             cb(null, sftp, null)

--- a/src/sshUtils.js
+++ b/src/sshUtils.js
@@ -79,7 +79,7 @@ function checkAuthentication(session) {
                 debugSFTP("Directory Exists: " + dir)
                 cb(null, sftp, dir)
               } else {
-                debugSFTP("Path is not a directory!")
+                debugSFTP("Path is not a directory! " + stat.permissions.toString(8))
                 cb(new Error("?dir:Not A Directory"))
               }
             });
@@ -90,7 +90,20 @@ function checkAuthentication(session) {
 
         // Check the user can open the directory
         function(sftp, dir, cb) {
-          cb(null)
+          if (dir) {
+            debugSFTP("Checking Directory Permissions: " + dir);
+            sftp.opendir(dir, (err, _) => {
+              if (err) {
+                cb(new Error("?dir:Permission Denied"))
+              } else {
+                session.ssh.dir = dir;
+                debugSFTP("Checked Directory Permissions")
+                cb(null)
+              }
+            });
+          } else {
+            cb(null)
+          }
         }
       ],
 

--- a/src/sshUtils.js
+++ b/src/sshUtils.js
@@ -84,7 +84,7 @@ function checkAuthentication(session) {
               }
             });
           } else {
-            cb(null, sftp);
+            cb(null, sftp, null);
           }
         },
 
@@ -96,7 +96,7 @@ function checkAuthentication(session) {
               if (err) {
                 cb(new Error("?dir:Permission Denied"))
               } else {
-                session.ssh.dir = dir;
+                session.ssh.cwd = dir;
                 debugSFTP("Checked Directory Permissions")
                 cb(null)
               }
@@ -117,7 +117,7 @@ function checkAuthentication(session) {
 
             // Ensure the SFTP variables are unset
             session.ssh.pwd = null;
-            session.ssh.dir = null;
+            session.ssh.cwd = null;
 
             // Pass control back to the caller
             reject(err);

--- a/src/sshUtils.js
+++ b/src/sshUtils.js
@@ -3,9 +3,10 @@
 const util = require('util')
 const SSH = require('ssh2').Client;
 const debug = require('debug');
-const debugSFTP = debug('flight:console:sftp');
 const debugSSH = debug('ssh2');
 const async = require('async');
+
+const DirectoryChecker = require('./directoryChecker');
 
 function checkAuthentication(session) {
   const result = new Promise((resolve, reject) => {
@@ -18,120 +19,24 @@ function checkAuthentication(session) {
       reject(error);
     }
 
+    const checker = new DirectoryChecker(conn, session.requestedDir);
     conn.on('ready', () => {
-      async.waterfall([
-        // Establish the SFTP connection
-        function(cb) {
-          debugSFTP("Starting SFTP check")
-          conn.sftp((err, sftp) => {
-            if (err) {
-              cb(err, null);
-            } else {
-              debugSFTP('Established SFTP client')
-              cb(null, sftp);
-            }
-          })
-        },
-
-        // Determine the PWD
-        function(sftp, cb) {
-          debugSFTP("Determining PWD");
-          sftp.realpath('.', (err, path) => {
-            if (err) {
-              cb(err);
-            } else {
-              session.ssh.pwd = path;
-              debug('Determined PWD: ' + path)
-              cb(null, sftp);
-            }
-          });
-        },
-
-        // Resolve the unverified_dir to an absolute path
-        function(sftp, cb) {
-          const d = session.unverified_dir
-          if (d && d.match(/^[0-9a-zA-Z_ u./-]*$/)) {
-            debugSFTP("Resolving: " + session.unverified_dir);
-            sftp.realpath(session.unverified_dir, (err, dir) => {
-              if (err) {
-                cb(err);
-              } else {
-                debugSFTP("Resolved: " + dir);
-                cb(null, sftp, dir);
-              }
-            });
-          } else if (d) {
-            debugSFTP("Invalid dir: " + d)
-            cb(new Error("?dir:Invalid Characters"));
-          } else {
-            // Trigger the next callback without a dir
-            cb(null, sftp, null)
-          }
-        },
-
-        // Check if the directory exists
-        function(sftp, dir, cb) {
-          if (dir) {
-            debugSFTP("Checking Directory Exists: " + dir);
-            sftp.stat(dir, (err, stat) => {
-              if (err && err.message == "No such file") {
-                cb(new Error("?dir:Missing Directory"));
-              } else if (err) {
-                cb(err)
-              } else if (stat.permissions >= 0o40000 && stat.permissions < 0o50000) {
-                // Checks the permissions to ensure it is a directory
-                debugSFTP("Directory Exists: " + dir)
-                cb(null, sftp, dir)
-              } else {
-                debugSFTP("Path is not a directory! " + stat.permissions.toString(8))
-                cb(new Error("?dir:Not A Directory"))
-              }
-            });
-          } else {
-            cb(null, sftp, null);
-          }
-        },
-
-        // Check the user can open the directory
-        function(sftp, dir, cb) {
-          if (dir) {
-            debugSFTP("Checking Directory Permissions: " + dir);
-            sftp.opendir(dir, (err, _) => {
-              if (err) {
-                cb(new Error("?dir:Permission Denied"))
-              } else {
-                session.ssh.cwd = dir;
-                debugSFTP("Checked Directory Permissions")
-                cb(null)
-              }
-            });
-          } else {
-            cb(null)
-          }
-        }
-      ],
-
-        // Final Callback, handle errors and close the connection
-        function(err) {
+      debug('SSH connection ready. Checking directory.');
+      checker.checkDirectory((err, pwd, cwd) => {
           conn.end()
           if (err) {
             // Handle unexpected errors
-            debugSFTP("The following error occurred during SFTP checks:");
-            debugSFTP(err);
-
-            // Ensure the SFTP variables are unset
-            session.ssh.pwd = null;
-            session.ssh.cwd = null;
-
-            // Pass control back to the caller
+            debug("The following error occurred checking the requested directory:");
+            debug(err);
             reject(err);
           } else {
-            // Pass control back to the caller
+            session.ssh.pwd = pwd;
+            session.ssh.cwd = cwd;
             resolve();
           }
-        }
-      )
+      });
     });
+
     conn.on('error', reject);
     const options = {
       ...connectionOptions(session),

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,6 +115,11 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^0.2.0, ansi-regex@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
+  integrity sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=
+
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
@@ -129,6 +134,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-styles@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.1.0.tgz#eaecbf66cd706882760b2f4691582b8f55d7a7de"
+  integrity sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -256,6 +266,20 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
+bl@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-0.4.2.tgz#5db31d72f038c54e68adc39578125fe3b0addc96"
+  integrity sha1-XbMdcvA4xU5orcOVeBJf47Ct3JY=
+  dependencies:
+    readable-stream "~1.0.2"
+
 blob@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
@@ -375,6 +399,17 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+chalk@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
+  integrity sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=
+  dependencies:
+    ansi-styles "^1.1.0"
+    escape-string-regexp "^1.0.0"
+    has-ansi "^0.1.0"
+    strip-ansi "^0.3.0"
+    supports-color "^0.2.0"
+
 chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -464,6 +499,11 @@ clone-response@^1.0.2:
   integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
   dependencies:
     mimic-response "^1.0.0"
+
+coffee-script@^1.8.0:
+  version "1.12.7"
+  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+  integrity sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -823,6 +863,14 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+deasync@~0.1.2:
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.23.tgz#d52bb1f9cebb511933bb977f2820af1af5d1ec08"
+  integrity sha512-CGZSokFwidI50GOAmkz/7z3QdMzTQqAiUOzt95PuhKgi6VVztn9D03ZCzzi93uUWlp/v6A9osvNWpIvqHvKjTA==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^1.7.1"
+
 debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
@@ -1113,7 +1161,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -1415,6 +1463,11 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -1673,6 +1726,13 @@ hard-rejection@^2.1.0:
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
   integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
 
+has-ansi@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-0.1.0.tgz#84f265aae8c0e6a88a12d7022894b7568894c62e"
+  integrity sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=
+  dependencies:
+    ansi-regex "^0.2.0"
+
 has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
@@ -1819,7 +1879,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2025,6 +2085,11 @@ is-yarn-global@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@2.0.1:
   version "2.0.1"
@@ -2563,6 +2628,11 @@ nodaemon@0.0.5:
   resolved "https://registry.yarnpkg.com/nodaemon/-/nodaemon-0.0.5.tgz#450a5450b6eac04227d2ad1da76263c47fdaedea"
   integrity sha512-4rfEhcDMZX/av809P6Yu9mxQf3qQL66fCOrAex+k6HkMnWKDd57IesiT4VCXUK4FTZWQ9MrvSZ76VrKgvSjnDg==
 
+node-addon-api@^1.7.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
+  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
+
 nodemon@^2.0.3:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.12.tgz#5dae4e162b617b91f1873b3bfea215dd71e144d5"
@@ -2640,6 +2710,11 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
+  integrity sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=
 
 object.assign@^4.1.0, object.assign@^4.1.2:
   version "4.1.2"
@@ -2959,6 +3034,17 @@ proxy-addr@~2.0.5:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+pryjs@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pryjs/-/pryjs-1.0.3.tgz#9aca80098ee5dde76b7a7bb6d38ec2ac720947cd"
+  integrity sha1-msqACY7l3edrenu2047CrHIJR80=
+  dependencies:
+    chalk "^0.5.1"
+    coffee-script "^1.8.0"
+    deasync "~0.1.2"
+    pygmentize-bundled "^2.3.0"
+    underscore "^1.7.0"
+
 pstree.remy@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
@@ -2983,6 +3069,14 @@ pupa@^2.0.1:
   integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
   dependencies:
     escape-goat "^2.0.0"
+
+pygmentize-bundled@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pygmentize-bundled/-/pygmentize-bundled-2.3.0.tgz#d425deda8d136975b933ede363135f623350814a"
+  integrity sha1-1CXe2o0TaXW5M+3jYxNfYjNQgUo=
+  dependencies:
+    bl "~0.4.1"
+    through2 "~0.2.1"
 
 q@^1.5.1:
   version "1.5.1"
@@ -3116,6 +3210,26 @@ readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-stream@~1.0.2:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
+readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readable-stream@~2.3.6:
   version "2.3.7"
@@ -3603,6 +3717,11 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -3614,6 +3733,13 @@ stringify-package@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
+
+strip-ansi@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.3.0.tgz#25f48ea22ca79187f3174a4db8759347bb126220"
+  integrity sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=
+  dependencies:
+    ansi-regex "^0.2.1"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -3662,6 +3788,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+supports-color@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
+  integrity sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=
 
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
@@ -3716,6 +3847,14 @@ through2@^4.0.0:
   integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
   dependencies:
     readable-stream "3"
+
+through2@~0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.2.3.tgz#eb3284da4ea311b6cc8ace3653748a52abf25a3f"
+  integrity sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=
+  dependencies:
+    readable-stream "~1.1.9"
+    xtend "~2.1.1"
 
 through@2, "through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
@@ -3868,6 +4007,11 @@ undefsafe@^2.0.3:
   integrity sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==
   dependencies:
     debug "^2.2.0"
+
+underscore@^1.7.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 uniq@^1.0.1:
   version "1.0.1"
@@ -4051,6 +4195,13 @@ xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xtend@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
+  integrity sha1-bv7MKk2tjmlixJAbM3znuoe10os=
+  dependencies:
+    object-keys "~0.4.0"
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
This PR moves the `SFTP` checks into the `sshUtils` library. This allows the errors to be reported back by the API.

The following error conditions are detected:

* Data is emitted to STDOUT within non-interactive login shells,
* The requested directory contains invalid characters,
* The requested directory does not exist,
* The requested directory is not a directory, and
* The user has invalid permissions to access the directory.

---

## Relative paths and Home directory

The user's "home directory" is now detected by expanding the path `.`. This is being reported back as the `pwd` attribute in the response payload. This is _technically_ the directory after the user's `.bashrc` is loaded. This _should_ be the user's home directory in most cases.

The `dir` parameter now supports relative paths, which are expanded from the above directory. The expanded directory is reported back as the `cwd` attribute.

---

## Error attributes

Two new error attributes have been added:

* `basic`: Flags errors which do not prevent the SSH connection from being established, and
* `type`: Used to identify errors which are the result of the SFTP or dir checks