### PR TITLE
Look for generic Flight Console API key instead of 'id_rsa'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 etc/config.json
 etc/shared-secret.conf
-etc/id_rsa*
+etc/flight_console_api_key*

--- a/etc/config.json.sample
+++ b/etc/config.json.sample
@@ -9,8 +9,8 @@
     "hosts": [
       { "host": null, "port": 22 }
     ],
-    "private_key_path": "./etc/id_rsa",
-    "public_key_path": "./etc/id_rsa.pub",
+    "private_key_path": "./etc/flight_console_api_key",
+    "public_key_path": "./etc/flight_console_api_key.pub",
     "localAddress": null,
     "localPort": null,
     "term": "xterm-color",

--- a/src/config.js
+++ b/src/config.js
@@ -18,8 +18,8 @@ const defaultConfig = {
     hosts: [
       { host: null, port: 22 }
     ],
-    private_key_path: path.join(configPath, '..', 'id_rsa'),
-    public_key_path: path.join(configPath, '..', 'id_rsa.pub'),
+    private_key_path: path.join(configPath, '..', 'flight_console_api_key'),
+    public_key_path: path.join(configPath, '..', 'flight_console_api_key.pub'),
     term: 'xterm-color',
     readyTimeout: 20000,
     keepaliveInterval: 120000,


### PR DESCRIPTION
This PR changes the default name of the private/public keys used to establish an SSH connection to something more generic. We will no longer be using `ssh-rsa` keys moving forward, so it makes sense to rename the key files too.